### PR TITLE
deps: bump nltk to 3.10.3 to clear reported advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ peft==0.18.1
 deepfilternet==0.5.6
 pyloudnorm
 future
-nltk==3.9.3
+nltk==3.10.3
 
 # NVIDIA Nemo (Canary) dependency
 Cython==3.2.4


### PR DESCRIPTION
Bumps nltk from 3.9.3 to 3.10.3 in requirements.txt.

Evidence:
- requirements.txt pinned nltk==3.9.3
- pip-audit 2.10.0 reported 9 advisories for nltk@3.9.3: PYSEC-2026-597, PYSEC-2026-2085, PYSEC-2026-2235, PYSEC-2026-2236, PYSEC-2026-2237, PYSEC-2026-3582, PYSEC-2026-3583, PYSEC-2026-3584, GHSA-rf74-v2fm-23pw (aliases include CVE-2026-12243, CVE-2026-12252)
- updated version: 3.10.3

Validation:
- pip-audit reports no known vulnerabilities for nltk@3.10.3
- `python3 -c "from nltk.tokenize import sent_tokenize"` passes with nltk 3.10.3 after downloading punkt_tab, the resource the project's sentence_split.py and TTS socket_server.py use

Scope: requirements.txt pin change only.
